### PR TITLE
chore: update the jsr version once

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://jsr.io/schema/config-file.v1.json",
   "name": "@chainsafe/benchmark",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "exports": {
     ".": "./src/index.ts",
     "./cli": "./src/cli/cli.ts"


### PR DESCRIPTION
**Motivation**

Update the JSR version matching to the upcoming release.

**Description**

We do the automated version bump for the file via 

https://github.com/ChainSafe/benchmark/blob/7ce43f3e27007c58d70129225c466606dc8346ec/release-please-config.json#L12-L14

Just found that release-please only update the files which were part of the previous release. Because this file is a new in current release so we have to update it's version manually. 

**Steps to test or reproduce**

Run all tests