### PR TITLE
ci: add the JWT token support for JSR publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      id-token: write # This is required for requesting the JWT for JSR release
+      id-token: write # The OIDC ID token is used for authentication with JSR.
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write # This is required for requesting the JWT for JSR release
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
**Motivation**

Make sure the JSR release works fine. 

**Description**

https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers#adding-permissions-settings

Can find more details on: 

https://github.com/ChainSafe/benchmark/actions/runs/14755102729/job/41425687685#step:9:1

**Steps to test or reproduce**

Run all tasks.