### PR TITLE
ci: use manifest config file for release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: node
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Motivation**

Use the release manifest configuration. 

**Description**

If we set a `release-type` for the action, it ignores the manifest configuration. 

https://github.com/googleapis/release-please-action?tab=readme-ov-file#advanced-release-configuration


**Steps to test or reproduce**

Run all workflows 