### PR TITLE
chore: remove npm token setup from release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,11 +39,7 @@ jobs:
         run: yarn build
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm config set //registry.npmjs.org/:_authToken=${{secrets.NPM_TOKEN}}
-
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: npm publish --access public
         if: ${{ steps.release.outputs.release_created }}
 


### PR DESCRIPTION
Removed npm authentication token configuration from workflow.

**Motivation**

Use the trusted publishing. 

**Description**

Remove NPM Token completely and rely on trusted publishing. 

